### PR TITLE
Change install script name

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Capgemini hackathon 2020",
   "main": "index.js",
   "scripts": {
-    "install": "npm install && npm --prefix ./backend install && npm --prefix ./frontend install",
+    "install:all": "npm install && npm --prefix ./backend install && npm --prefix ./frontend install",
     "dev": "concurrently \"npm run dev:backend\" \"npm run dev:frontend\"",
     "dev:backend": "npm --prefix ./backend run dev",
     "dev:frontend": "npm --prefix ./frontend start"


### PR DESCRIPTION
`npm run install` gave me infinite running script here. I think it is because of commmand `install` might be missinterpreted for something else. Changing to `install:all` works for me fine on ubuntu. I know it didn't work for some guys on windows, if that still the case we will need to update readme.